### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The default token issuer (`iss` claim) is your `APP_NAME` lowercase. You can spe
 
 **Audience**
 
-The default token audience (`aud` claim) is your `APP_NAME` lowercase. You can specify a different issuer name via `JWT_AUDIENCE`.
+The default token audience (`aud` claim) is your `APP_NAME` lowercase. You can specify a different audience name via `JWT_AUDIENCE`.
 
 ## Building tokens fluently
 


### PR DESCRIPTION
I noticed a small typo in the README and I'm assuming that it should have read **audience** instead **issuer** in the section about the Audience claim.